### PR TITLE
Laravel 11 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.2
-  - 7.3
-  - 7.4
+  - 8.2
+  - 8.3
+  - 8.4
 
 env:
   matrix:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/pagerduty/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/pagerduty/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/pagerduty.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/pagerduty)
 
-This package makes it easy to send notification events to [PagerDuty](https://www.pagerduty.com) with Laravel 5.5+, 6.x and 7.x
+This package makes it easy to send notification events to [PagerDuty](https://www.pagerduty.com) with Laravel 11.x+
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "guzzlehttp/guzzle": "~6.0|^7.0",
-        "illuminate/notifications": "~5.5 || ~6.0 || ~7.0 || ^8.0",
-        "illuminate/support": "~5.5 || ~6.0 || ~7.0 || ^8.0"
+        "php": ">=8.2",
+        "guzzlehttp/guzzle": "^7.8.2",
+        "illuminate/notifications": "^11.0",
+        "illuminate/support":  "^11.0"
     },
     "require-dev": {
-        "illuminate/queue": "~5.5 || ~6.0 || ~7.0 || ^8.0",
-        "mockery/mockery": "^1.2",
-        "phpunit/phpunit": "^8.5|^9.0"
+        "illuminate/queue": "^11.0",
+        "mockery/mockery": "^1.6.10",
+        "phpunit/phpunit": "^10.5.35|^11.3.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
+         failOnIncomplete="true"
+         failOnSkipped="true"
          stopOnFailure="false">
+
     <testsuites>
         <testsuite name="PagerDuty Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
+    <coverage>
+        <report>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/coverage"/>
+        </report>
+    </coverage>
+
     <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <junit outputFile="build/report.junit.xml"/>
     </logging>
 </phpunit>

--- a/src/Exceptions/ApiError.php
+++ b/src/Exceptions/ApiError.php
@@ -2,25 +2,27 @@
 
 namespace NotificationChannels\PagerDuty\Exceptions;
 
-class ApiError extends \Exception
+use Exception;
+
+class ApiError extends Exception
 {
-    public static function serviceBadRequest($response)
+    public static function serviceBadRequest(string $response): static
     {
         $response = json_decode($response, true);
 
-        $message = isset($response['message']) ? $response['message'] : '';
+        $message = $response['message'] ?? '';
         $errors = isset($response['errors']) ? implode(',', $response['errors']) : '';
 
         return new static("PagerDuty returned 400 Bad Request: $message - $errors");
     }
 
-    public static function rateLimit()
+    public static function rateLimit(): static
     {
         // https://v2.developer.pagerduty.com/docs/errors
         return new static('PagerDuty returned 429 Too Many Requests');
     }
 
-    public static function unknownError($code)
+    public static function unknownError(int $code): static
     {
         return new static("PagerDuty responded with an unexpected HTTP Status: $code");
     }

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -2,9 +2,11 @@
 
 namespace NotificationChannels\PagerDuty\Exceptions;
 
-class CouldNotSendNotification extends \Exception
+use Exception;
+
+class CouldNotSendNotification extends Exception
 {
-    public static function create(\Exception $e)
+    public static function create(Exception $e): static
     {
         return new static("Cannot send message to PagerDuty: {$e->getMessage()}", 0, $e);
     }

--- a/src/PagerDutyMessage.php
+++ b/src/PagerDutyMessage.php
@@ -9,10 +9,10 @@ class PagerDutyMessage
     const EVENT_TRIGGER = 'trigger';
     const EVENT_RESOLVE = 'resolve';
 
-    protected $payload = [];
-    protected $meta = [];
+    protected array $payload = [];
+    protected array $meta = [];
 
-    public static function create()
+    public static function create(): self
     {
         return new static();
     }
@@ -20,81 +20,80 @@ class PagerDutyMessage
     public function __construct()
     {
         Arr::set($this->meta, 'event_action', self::EVENT_TRIGGER);
-
         Arr::set($this->payload, 'source', gethostname());
         Arr::set($this->payload, 'severity', 'critical');
     }
 
-    public function setRoutingKey($value)
+    public function setRoutingKey(string $value): self
     {
         return $this->setMeta('routing_key', $value);
     }
 
-    public function resolve()
+    public function resolve(): self
     {
         return $this->setMeta('event_action', self::EVENT_RESOLVE);
     }
 
-    public function setDedupKey($key)
+    public function setDedupKey(string $key): self
     {
         return $this->setMeta('dedup_key', $key);
     }
 
-    public function setSummary($value)
+    public function setSummary(string $value): self
     {
         return $this->setPayload('summary', $value);
     }
 
-    public function setSource($value)
+    public function setSource(string $value): self
     {
         return $this->setPayload('source', $value);
     }
 
-    public function setSeverity($value)
+    public function setSeverity(string $value): self
     {
         return $this->setPayload('severity', $value);
     }
 
-    public function setTimestamp($value)
+    public function setTimestamp(string $value): self
     {
         return $this->setPayload('timestamp', $value);
     }
 
-    public function setComponent($value)
+    public function setComponent(string $value): self
     {
         return $this->setPayload('component', $value);
     }
 
-    public function setGroup($value)
+    public function setGroup(string $value): self
     {
         return $this->setPayload('group', $value);
     }
 
-    public function setClass($value)
+    public function setClass(string $value): self
     {
         return $this->setPayload('class', $value);
     }
 
-    public function addCustomDetail($key, $value)
+    public function addCustomDetail(string $key, string $value): self
     {
         return $this->setPayload("custom_details.$key", $value);
     }
 
-    protected function setPayload($key, $value)
+    protected function setPayload(string $key, mixed $value): self
     {
         Arr::set($this->payload, $key, $value);
 
         return $this;
     }
 
-    protected function setMeta($key, $value)
+    protected function setMeta(string $key, mixed $value): self
     {
         Arr::set($this->meta, $key, $value);
 
         return $this;
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return Arr::collapse([$this->meta, ['payload' => $this->payload]]);
     }

--- a/tests/PagerDutyChannelTest.php
+++ b/tests/PagerDutyChannelTest.php
@@ -10,7 +10,7 @@ use NotificationChannels\PagerDuty\PagerDutyChannel;
 use NotificationChannels\PagerDuty\PagerDutyMessage;
 use PHPUnit\Framework\TestCase;
 
-class ChannelTest extends TestCase
+class PagerDutyChannelTest extends TestCase
 {
     public function tearDown(): void
     {
@@ -20,24 +20,24 @@ class ChannelTest extends TestCase
         Mockery::close();
     }
 
-    /** @test */
-    public function it_can_send_a_notification()
+    public function test_it_can_send_a_notification()
     {
         $response = new Response(200);
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('post')
             ->once()
-            ->with('https://events.pagerduty.com/v2/enqueue',
+            ->with(
+                'https://events.pagerduty.com/v2/enqueue',
                 [
                     'body' => '{"event_action":"trigger","routing_key":"eventSource01","payload":{"source":"testSource","severity":"critical"}}',
-                ])
+                ]
+            )
             ->andReturn($response);
         $channel = new PagerDutyChannel($client);
         $channel->send(new TestNotifiable(), new TestNotification());
     }
 
-    /** @test */
-    public function it_skips_when_not_routable()
+    public function test_it_skips_when_not_routable()
     {
         $client = Mockery::mock(Client::class);
         $client->shouldNotReceive('post');
@@ -45,21 +45,20 @@ class ChannelTest extends TestCase
         $channel->send(new TestNotifiableUnRoutable(), new TestNotification());
     }
 
-    /**
-     * @test
-     */
-    public function it_throws_an_exception_when_400_bad_request()
+    public function test_it_throws_an_exception_when_400_bad_request()
     {
         $this->expectException('\NotificationChannels\PagerDuty\Exceptions\ApiError');
-        $this->expectExceptionMessage('PagerDuty returned 400 Bad Request: Event object is invalid - Length of \'routing_key\' is incorrect (should be 32 characters)');
+        $this->expectExceptionMessage(
+            'PagerDuty returned 400 Bad Request: Event object is invalid - Length of \'routing_key\' is incorrect (should be 32 characters)'
+        );
 
         $responseBody = '{
-  "status": "invalid event",
-  "message": "Event object is invalid",
-  "errors": [
-    "Length of \'routing_key\' is incorrect (should be 32 characters)"
-  ]
-}';
+          "status": "invalid event",
+          "message": "Event object is invalid",
+          "errors": [
+            "Length of \'routing_key\' is incorrect (should be 32 characters)"
+          ]
+        }';
 
         $response = new Response(400, [], $responseBody, '1.1', 'Bad Request');
         $client = Mockery::mock(Client::class);
@@ -70,10 +69,7 @@ class ChannelTest extends TestCase
         $channel->send(new TestNotifiable(), new TestNotification());
     }
 
-    /**
-     * @test
-     */
-    public function it_throws_the_expected_exception_if_error_response_doesnt_contain_expected_body_on_error()
+    public function test_it_throws_the_expected_exception_if_error_response_doesnt_contain_expected_body_on_error()
     {
         $this->expectException('\NotificationChannels\PagerDuty\Exceptions\ApiError');
         $this->expectExceptionMessage('PagerDuty returned 400 Bad Request:  -');
@@ -87,10 +83,7 @@ class ChannelTest extends TestCase
         $channel->send(new TestNotifiable(), new TestNotification());
     }
 
-    /**
-     * @test
-     */
-    public function it_throws_exception_on_rate_limit()
+    public function test_it_throws_exception_on_rate_limit()
     {
         $this->expectException('\NotificationChannels\PagerDuty\Exceptions\ApiError');
         $this->expectExceptionMessage('PagerDuty returned 429 Too Many Requests');
@@ -104,10 +97,7 @@ class ChannelTest extends TestCase
         $channel->send(new TestNotifiable(), new TestNotification());
     }
 
-    /**
-     * @test
-     */
-    public function it_throws_exception_on_unexpected_code()
+    public function test_it_throws_exception_on_unexpected_code()
     {
         $this->expectException('\NotificationChannels\PagerDuty\Exceptions\ApiError');
         $this->expectExceptionMessage('PagerDuty responded with an unexpected HTTP Status: 503');
@@ -121,10 +111,7 @@ class ChannelTest extends TestCase
         $channel->send(new TestNotifiable(), new TestNotification());
     }
 
-    /**
-     * @test
-     */
-    public function it_rethrows_exception_on_client_exception()
+    public function test_it_rethrows_exception_on_client_exception()
     {
         $this->expectException('\NotificationChannels\PagerDuty\Exceptions\CouldNotSendNotification');
         $this->expectExceptionMessage('Cannot send message to PagerDuty: Test Exception');

--- a/tests/PagerDutyMessageTest.php
+++ b/tests/PagerDutyMessageTest.php
@@ -7,8 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class PagerDutyMessageTest extends TestCase
 {
-    /** @test */
-    public function basic_message_has_all_values()
+    public function test_basic_message_has_all_values()
     {
         $message = PagerDutyMessage::create()
             ->setRoutingKey('testIntegration01')
@@ -26,7 +25,6 @@ class PagerDutyMessageTest extends TestCase
         $this->assertTrue(is_string($body['payload']['source']));
     }
 
-    /** @test */
     public function test_message_renders()
     {
         $message = PagerDutyMessage::create()
@@ -43,11 +41,11 @@ class PagerDutyMessageTest extends TestCase
                     'severity' => 'critical',
                     'summary' => 'This is a test message',
                 ],
-            ], $message->toArray()
+            ],
+            $message->toArray()
         );
     }
 
-    /** @test */
     public function test_message_renders_optional_params()
     {
         $message = PagerDutyMessage::create()
@@ -75,19 +73,19 @@ class PagerDutyMessageTest extends TestCase
                     'class' => 'ping failure',
                 ],
                 'dedup_key' => 'testMessage01',
-            ], $message->toArray()
+            ],
+            $message->toArray()
         );
     }
 
-    /** @test */
     public function test_message_renders_custom_details()
     {
         $message = PagerDutyMessage::create()
             ->setRoutingKey('testIntegration01')
             ->setSummary('This is a test message')
             ->setSource('testSource')
-        ->addCustomDetail('ping time', '1500ms')
-        ->addCustomDetail('load avg', '0.75');
+            ->addCustomDetail('ping time', '1500ms')
+            ->addCustomDetail('load avg', '0.75');
 
         $this->assertEquals(
             [
@@ -102,11 +100,11 @@ class PagerDutyMessageTest extends TestCase
                         'load avg' => '0.75',
                     ],
                 ],
-            ], $message->toArray()
+            ],
+            $message->toArray()
         );
     }
 
-    /** @test */
     public function test_message_renders_resolve()
     {
         $message = PagerDutyMessage::create()
@@ -124,7 +122,8 @@ class PagerDutyMessageTest extends TestCase
                     'severity' => 'critical',
                 ],
                 'dedup_key' => 'testMessage01',
-            ], $message->toArray()
+            ],
+            $message->toArray()
         );
     }
 }


### PR DESCRIPTION
## Laravel 11 Support 

- upgraded composer dependencies
  - Minimum PHP version is now 8.2
  - Minimum Laravel version is now 11
- added types/formatting updates to classes
- fixed phpunit deprecations
- updated pipelines