### PR TITLE
Allow installing with illuminate/* 9.x and 10.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "require": {
         "php": ">=7.1",
         "guzzlehttp/guzzle": "~6.0|^7.0",
-        "illuminate/notifications": "~5.5 || ~6.0 || ~7.0 || ^8.0",
-        "illuminate/support": "~5.5 || ~6.0 || ~7.0 || ^8.0"
+        "illuminate/notifications": "^10.0",
+        "illuminate/support": "~5.5 || ~6.0 || ~7.0 || ^8.0 || ^9.0 || ^10.0"
     },
     "require-dev": {
-        "illuminate/queue": "~5.5 || ~6.0 || ~7.0 || ^8.0",
+        "illuminate/queue": "~5.5 || ~6.0 || ~7.0 || ^8.0 || ^9.0 || ^10.0",
         "mockery/mockery": "^1.2",
         "phpunit/phpunit": "^8.5|^9.0"
     },


### PR DESCRIPTION
This PR allows installing the package on projects running Laravel 9 and 10.

The package tests are passing when ran with both `illuminate/* ^9` and `^10`.